### PR TITLE
Create config/deploy directory if not created

### DIFF
--- a/lib/mina/multistage.rb
+++ b/lib/mina/multistage.rb
@@ -27,6 +27,8 @@ end
 namespace :multistage do
   desc "Create development, staging, and production stage files"
   task :create_stagefiles do
+    Dir.mkdir location if !File.exists? location
+
     %w{ development staging production }.each do |stage|
       stagefile = File.join(location, "#{stage}.rb")
       if !File.exists?(stagefile)


### PR DESCRIPTION
In order to ensure the multisite:create_stagefiles mina task works as
expected on a fresh install, this commit adds a check to see if the
directory exists and creates it if it doesn't.
