### PR TITLE
Add versions badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Stories in Ready](https://badge.waffle.io/Endoze/mina-multistage.png?label=ready)](https://waffle.io/Endoze/mina-multistage)  
+[![Gem Version](https://badge.fury.io/rb/mina-multistage.png)](http://badge.fury.io/rb/mina-multistage) [![Stories in Ready](https://badge.waffle.io/Endoze/mina-multistage.png?label=ready)](https://waffle.io/Endoze/mina-multistage)  
+
 # Mina::Multistage
 
 Plugin for Mina that adds support for multiple stages.


### PR DESCRIPTION
In order to display the latest version of the gem from rubygems.org,
this commit adds the versions badge to the repo readme.
