### PR TITLE
Fix settings accessible between tasks

### DIFF
--- a/lib/mina/multistage.rb
+++ b/lib/mina/multistage.rb
@@ -42,7 +42,13 @@ all_stages.each do |name|
   end
 end
 
-invoke _default_stage if _stage_file_exists?(_default_stage) && !_argument_included_in_stages?(ARGV.first)
+_potential_stage = ARGV.first
+
+if _argument_included_in_stages?(_potential_stage)
+ invoke _potential_stage
+elsif _stage_file_exists?(_default_stage)
+ invoke _default_stage
+end
 
 namespace :multistage do
   desc 'Create stage files'

--- a/lib/mina/multistage.rb
+++ b/lib/mina/multistage.rb
@@ -44,7 +44,7 @@ end
 
 _potential_stage = ARGV.first
 
-if _argument_included_in_stages?(_potential_stage)
+if _stage_file_exists?(_potential_stage) && _argument_included_in_stages?(_potential_stage)
  invoke _potential_stage
 elsif _stage_file_exists?(_default_stage)
  invoke _default_stage

--- a/lib/mina/multistage/version.rb
+++ b/lib/mina/multistage/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Multistage
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
### Problem:
```ruby
# deploy/beta.rb
set :domain, 'beta.example.com'
set :deploy_to, '/usr/share/nginx/html/example'
set :branch, 'beta'
```

```ruby
# deploy/production.rb
set :domain, 'example.com'
set :deploy_to, '/usr/share/nginx/html/example'
set :branch, 'production'
```

```ruby
# deploy.rb
set :default_stage, 'production'
# ...
puts domain
# ...
```

These are my config files use the lasted release,
and below is my result.

```ruby
#  Work fine
mina deploy #=> example.com
# It's should be "beta.example.com"
mina beta deploy #=> nil
# It's should be "example.com"
mina production deploy #=> nil
```

Whe invoke `mina deploy`, it outputs `example.com` which is we expected.
`mina beta deploy` outputs nothing(`nil`) which is supposed to output `beta.example.com`.
And `mina production deploy` should be outputed `example.com` rather than nothing(`nil`)

### Fixed:
```ruby
mina deploy #=> example.com
mina beta deploy #=> beta.example.com
mina production deploy #=> example.com
```