### PR TITLE
Use fetch instead of relying on method missing for variables

### DIFF
--- a/lib/mina/multistage.rb
+++ b/lib/mina/multistage.rb
@@ -28,16 +28,16 @@ def _get_all_stages
 end
 
 def _argument_included_in_stages?(arg)
-  all_stages.include?(arg)
+  fetch(:all_stages).include?(arg)
 end
 
 set :all_stages, _get_all_stages if _all_stages_empty?
 
-all_stages.each do |name|
+fetch(:all_stages).each do |name|
   desc "Set the target stage to '#{name}'."
   task(name) do
     set :stage, name
-    file = "#{_stages_dir}/#{stage}.rb"
+    file = "#{_stages_dir}/#{fetch(:stage)}.rb"
     load file
   end
 end


### PR DESCRIPTION
Hi, I used mina 1.0.0rc2 and code have method_missing. It's delete. 
All variable need to use fetch replace.
Please to check it. Thanks