### PR TITLE
Update version to 1.0.3

### DIFF
--- a/lib/mina/multistage/version.rb
+++ b/lib/mina/multistage/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Multistage
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end

--- a/mina_multistage.gemspec
+++ b/mina_multistage.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mina", ">= 0.2.1"
+  spec.add_dependency "mina", "~> 1.0"
   spec.add_development_dependency "bundler", ">= 1.3.5"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This commit updates the version to 1.0.3. It also changes the mina
dependency to use the pessimistic operator to keep it dependent on
a semantically compatible version of mina.