### PR TITLE
revert mina dependency

### DIFF
--- a/mina_multistage.gemspec
+++ b/mina_multistage.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mina", "~> 1.0"
+  spec.add_dependency "mina", ">= 0.2.1"
   spec.add_development_dependency "bundler", ">= 1.3.5"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Mina > 0.3 is not yet adopted by the majority. This gem is popular and bumping dependency w/o any purpose is a very bad idea.
Such bump should go in v2 to give people clear understanding that there is abyss between them.