### PR TITLE
Replace deprecated File.exists? by File.exist?

### DIFF
--- a/lib/mina/multistage.rb
+++ b/lib/mina/multistage.rb
@@ -20,7 +20,7 @@ def _file_for_stage(stage_name)
 end
 
 def _stage_file_exists?(stage_name)
-  File.exists?(File.expand_path(_file_for_stage(stage_name)))
+  File.exist?(File.expand_path(_file_for_stage(stage_name)))
 end
 
 def _get_all_stages
@@ -53,7 +53,7 @@ end
 namespace :multistage do
   desc 'Create stage files'
   task :init do
-    FileUtils.mkdir_p _stages_dir if !File.exists? _stages_dir
+    FileUtils.mkdir_p _stages_dir if !File.exist? _stages_dir
     _default_stages.each do |stage|
       stagefile = _file_for_stage(stage)
       if !_stage_file_exists?(stage)


### PR DESCRIPTION
Ruby 3.2 has removed `File.exists?` (which was deprecated since 2.1) in favour of `File.exist?`. See https://bugs.ruby-lang.org/issues/17391

Workaround in the meantime: https://github.com/Largo/file_exists